### PR TITLE
Multiple wallets & consolidation transaction tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Can be easily modified for any other format as well.
 ## How to use?
 
 1) Copy sample_dotenv by name .env
-2) Edit it and set nice environment variable names, and comma-separated list of your wallet addresses. For best results, include all addresses your wallet is using (otherwise it cannot track internal transfers correctly). Currently the code uses two env variables, but adjust both .env file to add any number of wallets.
+2) Edit it and set nice environment variable names, and comma-separated list of your wallet addresses. For best results, include all addresses your wallet is using (otherwise it cannot track internal transfers correctly). Currently the code uses two env variables, adjust .env file to add any number of wallets.
 3) Run the tool:
     python3 export_all.py
 4) Observe transaction .csv files getting created

--- a/README.md
+++ b/README.md
@@ -14,13 +14,9 @@ Can be easily modified for any other format as well.
 
 ## Prerequisites
 
-Need to have Python 3
-Need to have some Python libs installed, with pip.
-You can get a pretty good idea from tool imports, but at least:
+Python 3
+The `requirements.txt` file lists all Python libraries the script depends on.  They can be installed using:
 
-```bash
-pip install requests
-pip install pandas
-pip install dotenv
-pip install jinja2
+```
+pip install -r requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Can be easily modified for any other format as well.
 ## How to use?
 
 1) Copy sample_dotenv by name .env
-2) Edit it and set nice environment variable names, and comma-separated list of your wallet addresses. For best results, include all addresses your wallet is using (otherwise it cannot track internal transfers correctly). Currently the code uses two env variables, but adjust both .env file and the code to your likings (See the main function at the bottom of the file).
+2) Edit it and set nice environment variable names, and comma-separated list of your wallet addresses. For best results, include all addresses your wallet is using (otherwise it cannot track internal transfers correctly). Currently the code uses two env variables, but adjust both .env file to add any number of wallets.
 3) Run the tool:
     python3 export_all.py
 4) Observe transaction .csv files getting created

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+certifi==2022.12.7
+charset-normalizer==3.0.1
+idna==3.4
+numpy==1.24.2
+pandas==1.5.3
+python-dateutil==2.8.2
+python-dotenv==0.21.1
+pytz==2022.7.1
+requests==2.28.2
+six==1.16.0
+urllib3==1.26.14


### PR DESCRIPTION
Updated wallet handling to loop through all wallets in dotenv file instead of specifying them individually.  

Added numeric_only=False argument to .sum() because default value is deprecated.  

Split wallet consolidation transaction into a sending row and a receiving row with the same TxHash.  The two transactions can be merged in Koinly which seems to play nicer with their transaction processing.  

Added requirements.txt file for dependencies and updated Readme to reflect that change